### PR TITLE
Update styles for new cookie policy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "o-colors": "^3.5.0",
     "o-typography": "^4.3.1",
+		"o-grid": "^4.2.3",
     "o-icons": ">=4.4.2 <6"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "o-colors": "^3.5.0",
     "o-typography": "^4.3.1",
-		"o-grid": "^4.2.3",
+    "o-grid": "^4.2.3",
     "o-icons": ">=4.4.2 <6"
   }
 }

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,11 +1,7 @@
 <div class="o-cookie-message o-cookie-message--banner-centric" data-o-component="o-cookie-message">
     <div class="o-cookie-message__container">
         <p class="o-cookie-message__description">
-            By continuing to use this site you consent to the use of cookies.&nbsp;
-            <a class="o-cookie-message__link"
-               href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">
-                Find out more
-            </a>
+            By continuing to use this site you consent to the use of cookies on your device as described in our <a href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">cookie policy</a> unless you have disabled them. You can change your cookie settings at any time but parts of our site will not function correctly without them.
         </p>
         <div class="o-cookie-message__close-btn-container">
             <button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 @import "o-colors/main";
 @import "o-typography/main";
 @import "o-icons/main";
+@import "o-grid/main";
 @import "src/scss/variables";
 
 @if ($o-cookie-message-is-silent == false) {
@@ -27,6 +28,7 @@
         }
 
         &__close-btn {
+            margin-top: -3px; /* magic number to get the button to line up with the text */
             position: relative;
             padding: 0;
             width: 25px;
@@ -67,13 +69,12 @@
         }
 
         &__description {
-            @include oTypographySans(m);
+            @include oTypographySans(s);
             margin: 0;
-            font-size: 18px;
             color: oColorsGetColorFor(page, text);
         }
 
-        &__link {
+        a {
             text-decoration: none;
             color: oColorsGetColorFor(link, text);
         }
@@ -95,7 +96,7 @@
     .o-cookie-message.o-cookie-message--banner-centric {
 
         .o-cookie-message__container {
-            max-width: 728px;
+            @include oGridContainer();
             margin-left: auto;
             margin-right: auto;
         }

--- a/main.scss
+++ b/main.scss
@@ -22,24 +22,24 @@
         }
 
         &__close-btn-container {
+            margin-top: -3px; // Magic number to make cross line up with top line of copy
             position: absolute;
             top: 0;
             right: 0;
         }
 
         &__close-btn {
-            margin-top: -3px; /* magic number to get the button to line up with the text */
             position: relative;
             padding: 0;
-            width: 25px;
-            height: 25px;
+            width: $_o-cookie-message-icon-size + 0px; // Hack to get a `px` at the end
+            height: $_o-cookie-message-icon-size + 0px;
             border: 0;
             background: none;
             cursor: pointer;
             opacity: 0.8;
 
             &:before {
-                @include oIconsGetIcon(cross, oColorsGetColorFor(page, text), 25, $iconset-version: 1);
+                @include oIconsGetIcon(cross, oColorsGetColorFor(page, text), $_o-cookie-message-icon-size, $iconset-version: 1);
                 content: '';
 
             }
@@ -69,7 +69,10 @@
         }
 
         &__description {
-            @include oTypographySans(s);
+            @include oTypographySans(xs);
+            font-size: 13px; // override these values
+            line-height: 15px;
+            padding-right: 30px;
             margin: 0;
             color: oColorsGetColorFor(page, text);
         }
@@ -102,6 +105,6 @@
         }
     }
 
-	// Set to silent again to avoid being output twice
-	$o-cookie-message-is-silent: true !global;
+  // Set to silent again to avoid being output twice
+  $o-cookie-message-is-silent: true !global;
 }

--- a/main.scss
+++ b/main.scss
@@ -105,6 +105,6 @@
         }
     }
 
-  // Set to silent again to avoid being output twice
-  $o-cookie-message-is-silent: true !global;
+    // Set to silent again to avoid being output twice
+    $o-cookie-message-is-silent: true !global;
 }

--- a/origami.json
+++ b/origami.json
@@ -1,26 +1,26 @@
 {
-		"description": "Component description",
-		"origamiType": "module",
-		"origamiCategory": "components",
-		"origamiVersion": 1,
-		"support": "https://github.com/Financial-Times/o-cookie-message/issues",
-		"supportStatus": "active",
-		"browserFeatures": {},
-		"ci": {
-			"circle": "https://circleci.com/api/v1/project/Financial-Times/o-cookie-message"
-		},
-		"demosDefaults": {
-			"sass": "demos/src/demo.scss",
-			"documentClasses": "",
-			"dependencies": ""
-		},
-		"demos": [
-			{
-				"name": "demo",
-				"js": "demos/src/demo.js",
-				"template": "demos/src/demo.mustache",
-				"hidden": true,
-				"description": ""
-			}
-		]
-	}
+	"description": "Component description",
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"support": "https://github.com/Financial-Times/o-cookie-message/issues",
+	"supportStatus": "active",
+	"browserFeatures": {},
+	"ci": {
+		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-cookie-message"
+	},
+	"demosDefaults": {
+		"sass": "demos/src/demo.scss",
+		"documentClasses": "",
+		"dependencies": ""
+	},
+	"demos": [
+		{
+			"name": "demo",
+			"js": "demos/src/demo.js",
+			"template": "demos/src/demo.mustache",
+			"hidden": true,
+			"description": ""
+		}
+	]
+}

--- a/origami.json
+++ b/origami.json
@@ -12,7 +12,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"documentClasses": "",
-		"dependencies": ""
+		"dependencies": "o-fonts"
 	},
 	"demos": [
 		{

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,1 +1,2 @@
 $o-cookie-message-is-silent: true !default;
+$_o-cookie-message-icon-size: 25;


### PR DESCRIPTION
The cookie policy previously defined here was very short but legal have instructed us to update it to the longer version.

So that on mobile this update doesn't take up a large amount of the screen, this PR reduces the font size of the message down to 13px.

This PR also widens the message to the grid width and updates the demo.

Before: 
![screen shot 2016-09-28 at 11 14 37](https://cloud.githubusercontent.com/assets/68009/18909829/1259c74c-856d-11e6-8feb-ee1614e7d24a.png)

After:
![screen shot 2016-09-28 at 11 13 44](https://cloud.githubusercontent.com/assets/68009/18909833/15904256-856d-11e6-97af-464b8028dc4a.png)

This will have to be a breaking change as the new design for the cookie message doesn't work with the shorter wordcount of the original message