### PR TITLE
Convert whitespace

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   ],
   "main": [
     "main.scss",
-		"main.js"
+    "main.js"
   ],
   "dependencies": {
     "o-colors": "^3.5.0",

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,16 +1,16 @@
 <div class="o-cookie-message o-cookie-message--banner-centric" data-o-component="o-cookie-message">
-    <div class="o-cookie-message__container">
-        <p class="o-cookie-message__description">
-            By continuing to use this site you consent to the use of cookies.&nbsp;
-            <a class="o-cookie-message__link"
-               href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">
-                Find out more
-            </a>
-        </p>
-        <div class="o-cookie-message__close-btn-container">
-            <button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">
-                <span class="o-cookie-message__close-btn-label">Close</span>
-            </button>
-        </div>
-    </div>
+	<div class="o-cookie-message__container">
+		<p class="o-cookie-message__description">
+			By continuing to use this site you consent to the use of cookies.&nbsp;
+			<a class="o-cookie-message__link"
+				 href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">
+					Find out more
+			</a>
+		</p>
+		<div class="o-cookie-message__close-btn-container">
+			<button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">
+					<span class="o-cookie-message__close-btn-label">Close</span>
+			</button>
+		</div>
+	</div>
 </div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function(config) {
 			},
 			plugins: [
 				new BowerPlugin({
-					includes:  /\.js$/
+					includes: /\.js$/
 				})
 			]
 		},

--- a/main.scss
+++ b/main.scss
@@ -4,102 +4,102 @@
 @import "src/scss/variables";
 
 @if ($o-cookie-message-is-silent == false) {
-    /*------------------------------------*\
-            #BLOCK-DESKTOP
-    \*------------------------------------*/
+	/*------------------------------------*\
+			#BLOCK-DESKTOP
+	\*------------------------------------*/
 
-    .o-cookie-message {
-        display: none;
-        position: relative;
-        background-color: oColorsGetColorFor(box, background);
-        border-bottom: 1px solid oColorsGetPaletteColor('pink-tint3');
-        padding: 5px 15px;
+	.o-cookie-message {
+		display: none;
+		position: relative;
+		background-color: oColorsGetColorFor(box, background);
+		border-bottom: 1px solid oColorsGetPaletteColor('pink-tint3');
+		padding: 5px 15px;
 
-        &__container {
-            position: relative;
-            padding-right: 25px;
-        }
+		&__container {
+			position: relative;
+			padding-right: 25px;
+		}
 
-        &__close-btn-container {
-            position: absolute;
-            top: 0;
-            right: 0;
-        }
+		&__close-btn-container {
+			position: absolute;
+			top: 0;
+			right: 0;
+		}
 
-        &__close-btn {
-            position: relative;
-            padding: 0;
-            width: 25px;
-            height: 25px;
-            border: 0;
-            background: none;
-            cursor: pointer;
-            opacity: 0.8;
+		&__close-btn {
+			position: relative;
+			padding: 0;
+			width: 25px;
+			height: 25px;
+			border: 0;
+			background: none;
+			cursor: pointer;
+			opacity: 0.8;
 
-            &:before {
-                @include oIconsGetIcon(cross, oColorsGetColorFor(page, text), 25, $iconset-version: 1);
-                content: '';
+			&:before {
+				@include oIconsGetIcon(cross, oColorsGetColorFor(page, text), 25, $iconset-version: 1);
+				content: '';
 
-            }
+			}
 
-            &:hover {
-                opacity: 1;
-            }
-        }
+			&:hover {
+				opacity: 1;
+			}
+		}
 
-        &__close-btn-label {
-            /* For more info: https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-            margin: -1px;
-            padding: 0;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-            clip: rect(0 0 0 0); /* IE6, IE7 */
-            clip: rect(0, 0, 0, 0);
-            position: absolute;
-        }
+		&__close-btn-label {
+			/* For more info: https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+			margin: -1px;
+			padding: 0;
+			width: 1px;
+			height: 1px;
+			overflow: hidden;
+			clip: rect(0 0 0 0); /* IE6, IE7 */
+			clip: rect(0, 0, 0, 0);
+			position: absolute;
+		}
 
-        &__title {
-            @include oTypographySansBold(l);
-            color: oColorsGetColorFor(page, text);
-            margin: 0;
-            font-size: 18px;
-        }
+		&__title {
+			@include oTypographySansBold(l);
+			color: oColorsGetColorFor(page, text);
+			margin: 0;
+			font-size: 18px;
+		}
 
-        &__description {
-            @include oTypographySans(m);
-            margin: 0;
-            font-size: 18px;
-            color: oColorsGetColorFor(page, text);
-        }
+		&__description {
+			@include oTypographySans(m);
+			margin: 0;
+			font-size: 18px;
+			color: oColorsGetColorFor(page, text);
+		}
 
-        &__link {
-            text-decoration: none;
-            color: oColorsGetColorFor(link, text);
-        }
-    }
+		&__link {
+			text-decoration: none;
+			color: oColorsGetColorFor(link, text);
+		}
+	}
 
-    /*------------------------------------*\
-            #BLOCK-MODIFIERS
-    \*------------------------------------*/
+	/*------------------------------------*\
+			#BLOCK-MODIFIERS
+	\*------------------------------------*/
 
-    .o-cookie-message--active {
-        display: block;
-    }
+	.o-cookie-message--active {
+		display: block;
+	}
 
-    /**
-    * The `--banner-centric` modifier center aligns the content so that it will
-    * align with a 728px width banner that is position beneath the message,
-    * as will be the case on next.ft.com
-    */
-    .o-cookie-message.o-cookie-message--banner-centric {
+	/**
+	* The `--banner-centric` modifier center aligns the content so that it will
+	* align with a 728px width banner that is position beneath the message,
+	* as will be the case on next.ft.com
+	*/
+	.o-cookie-message.o-cookie-message--banner-centric {
 
-        .o-cookie-message__container {
-            max-width: 728px;
-            margin-left: auto;
-            margin-right: auto;
-        }
-    }
+		.o-cookie-message__container {
+			max-width: 728px;
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 
 	// Set to silent again to avoid being output twice
 	$o-cookie-message-is-silent: true !global;

--- a/origami.json
+++ b/origami.json
@@ -1,26 +1,26 @@
 {
-		"description": "Component description",
-		"origamiType": "module",
-		"origamiCategory": "components",
-		"origamiVersion": 1,
-		"support": "https://github.com/Financial-Times/o-cookie-message/issues",
-		"supportStatus": "active",
-		"browserFeatures": {},
-		"ci": {
-			"circle": "https://circleci.com/api/v1/project/Financial-Times/o-cookie-message"
-		},
-		"demosDefaults": {
-			"sass": "demos/src/demo.scss",
-			"documentClasses": "",
-			"dependencies": ""
-		},
-		"demos": [
-			{
-				"name": "demo",
-				"js": "demos/src/demo.js",
-				"template": "demos/src/demo.mustache",
-				"hidden": true,
-				"description": ""
-			}
-		]
-	}
+	"description": "Component description",
+	"origamiType": "module",
+	"origamiCategory": "components",
+	"origamiVersion": 1,
+	"support": "https://github.com/Financial-Times/o-cookie-message/issues",
+	"supportStatus": "active",
+	"browserFeatures": {},
+	"ci": {
+		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-cookie-message"
+	},
+	"demosDefaults": {
+		"sass": "demos/src/demo.scss",
+		"documentClasses": "",
+		"dependencies": ""
+	},
+	"demos": [
+		{
+			"name": "demo",
+			"js": "demos/src/demo.js",
+			"template": "demos/src/demo.mustache",
+			"hidden": true,
+			"description": ""
+		}
+	]
+}


### PR DESCRIPTION
The whitespace in this project is a bit bananas and unlike any other
Origami component whitespace (4 spaces instead of a tab)
This commit converts it to be 1 tab indent, except for package.json
and bower.json which will get automatically rewritten as 2 spaces
by bower and npm, and circle.yml for which tabs are invalid.