### PR TITLE
Convert whitespace

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   ],
   "main": [
     "main.scss",
-		"main.js"
+    "main.js"
   ],
   "dependencies": {
     "o-colors": "^3.5.0",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function(config) {
 			},
 			plugins: [
 				new BowerPlugin({
-					includes:  /\.js$/
+					includes: /\.js$/
 				})
 			]
 		},

--- a/main.scss
+++ b/main.scss
@@ -5,106 +5,106 @@
 @import "src/scss/variables";
 
 @if ($o-cookie-message-is-silent == false) {
-    /*------------------------------------*\
-            #BLOCK-DESKTOP
-    \*------------------------------------*/
+	/*------------------------------------*\
+			#BLOCK-DESKTOP
+	\*------------------------------------*/
 
-    .o-cookie-message {
-        display: none;
-        position: relative;
-        background-color: oColorsGetColorFor(box, background);
-        border-bottom: 1px solid oColorsGetPaletteColor('pink-tint3');
-        padding: 5px 15px;
+	.o-cookie-message {
+		display: none;
+		position: relative;
+		background-color: oColorsGetColorFor(box, background);
+		border-bottom: 1px solid oColorsGetPaletteColor('pink-tint3');
+		padding: 5px 15px;
 
-        &__container {
-            position: relative;
-            padding-right: 25px;
-        }
+		&__container {
+			position: relative;
+			padding-right: 25px;
+		}
 
-        &__close-btn-container {
-            margin-top: -3px; // Magic number to make cross line up with top line of copy
-            position: absolute;
-            top: 0;
-            right: 0;
-        }
+		&__close-btn-container {
+			margin-top: -3px; // Magic number to make cross line up with top line of copy
+			position: absolute;
+			top: 0;
+			right: 0;
+		}
 
-        &__close-btn {
-            position: relative;
-            padding: 0;
-            width: $_o-cookie-message-icon-size + 0px; // Hack to get a `px` at the end
-            height: $_o-cookie-message-icon-size + 0px;
-            border: 0;
-            background: none;
-            cursor: pointer;
-            opacity: 0.8;
+		&__close-btn {
+			position: relative;
+			padding: 0;
+			width: $_o-cookie-message-icon-size + 0px; // Hack to get a `px` at the end
+			height: $_o-cookie-message-icon-size + 0px;
+			border: 0;
+			background: none;
+			cursor: pointer;
+			opacity: 0.8;
 
-            &:before {
-                @include oIconsGetIcon(cross, oColorsGetColorFor(page, text), $_o-cookie-message-icon-size, $iconset-version: 1);
-                content: '';
+			&:before {
+				@include oIconsGetIcon(cross, oColorsGetColorFor(page, text), $_o-cookie-message-icon-size, $iconset-version: 1);
+				content: '';
 
-            }
+			}
 
-            &:hover {
-                opacity: 1;
-            }
-        }
+			&:hover {
+				opacity: 1;
+			}
+		}
 
-        &__close-btn-label {
-            /* For more info: https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-            margin: -1px;
-            padding: 0;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-            clip: rect(0 0 0 0); /* IE6, IE7 */
-            clip: rect(0, 0, 0, 0);
-            position: absolute;
-        }
+		&__close-btn-label {
+			/* For more info: https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+			margin: -1px;
+			padding: 0;
+			width: 1px;
+			height: 1px;
+			overflow: hidden;
+			clip: rect(0 0 0 0); /* IE6, IE7 */
+			clip: rect(0, 0, 0, 0);
+			position: absolute;
+		}
 
-        &__title {
-            @include oTypographySansBold(l);
-            color: oColorsGetColorFor(page, text);
-            margin: 0;
-            font-size: 18px;
-        }
+		&__title {
+			@include oTypographySansBold(l);
+			color: oColorsGetColorFor(page, text);
+			margin: 0;
+			font-size: 18px;
+		}
 
-        &__description {
-            @include oTypographySans(xs);
-            font-size: 13px; // override these values
-            line-height: 15px;
-            padding-right: 30px;
-            margin: 0;
-            color: oColorsGetColorFor(page, text);
-        }
+		&__description {
+			@include oTypographySans(xs);
+			font-size: 13px; // override these values
+			line-height: 15px;
+			padding-right: 30px;
+			margin: 0;
+			color: oColorsGetColorFor(page, text);
+		}
 
-        a {
-            text-decoration: none;
-            color: oColorsGetColorFor(link, text);
-        }
-    }
+		a {
+			text-decoration: none;
+			color: oColorsGetColorFor(link, text);
+		}
+	}
 
-    /*------------------------------------*\
-            #BLOCK-MODIFIERS
-    \*------------------------------------*/
+	/*------------------------------------*\
+			#BLOCK-MODIFIERS
+	\*------------------------------------*/
 
-    .o-cookie-message--active {
-        display: block;
-    }
+	.o-cookie-message--active {
+		display: block;
+	}
 
-    /**
-    * The `--banner-centric` modifier center aligns the content so that it will
-    * align with a 728px width banner that is position beneath the message,
-    * as will be the case on next.ft.com
-    */
-    .o-cookie-message.o-cookie-message--banner-centric {
+	/**
+	* The `--banner-centric` modifier center aligns the content so that it will
+	* align with a 728px width banner that is position beneath the message,
+	* as will be the case on next.ft.com
+	*/
+	.o-cookie-message.o-cookie-message--banner-centric {
 
-        .o-cookie-message__container {
-            @include oGridContainer();
-            margin-left: auto;
-            margin-right: auto;
-        }
-    }
+		.o-cookie-message__container {
+			@include oGridContainer();
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 
-    // Set to silent again to avoid being output twice
-    $o-cookie-message-is-silent: true !global;
+	// Set to silent again to avoid being output twice
+	$o-cookie-message-is-silent: true !global;
 }


### PR DESCRIPTION
The whitespace in this project is a bit bananas and unlike any other
Origami component whitespace (4 spaces instead of a tab)
This commit converts it to be 1 tab indent, except for package.json
and bower.json which will get automatically rewritten as 2 spaces
by bower and npm, and circle.yml for which tabs are invalid.