### PR TITLE
Fix alignment

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -14,7 +14,7 @@
 		position: relative;
 		background-color: oColorsGetColorFor(box, background);
 		border-bottom: 1px solid oColorsGetPaletteColor('pink-tint3');
-		padding: 5px 15px;
+		padding: 5px 0;
 
 		&__container {
 			position: relative;
@@ -22,10 +22,10 @@
 		}
 
 		&__close-btn-container {
-			margin-top: -3px; // Magic number to make cross line up with top line of copy
+			margin-top: -4px; // Magic number to make cross line up with top line of copy
 			position: absolute;
 			top: 0;
-			right: 0;
+			right: -$_o-cookie-message-icon-size/3 +0px;
 		}
 
 		&__close-btn {
@@ -72,7 +72,7 @@
 			@include oTypographySans(xs);
 			font-size: 13px; // override these values
 			line-height: 15px;
-			padding-right: 30px;
+			padding-right: 15px;
 			margin: 0;
 			color: oColorsGetColorFor(page, text);
 		}
@@ -100,8 +100,9 @@
 
 		.o-cookie-message__container {
 			@include oGridContainer();
-			margin-left: auto;
-			margin-right: auto;
+			> div {
+				position: relative;
+			}
 		}
 	}
 

--- a/src/js/cookieMessage.js
+++ b/src/js/cookieMessage.js
@@ -23,6 +23,7 @@ class CookieMessage {
 	static cookieHTML () {
 		return `
 			<div class="o-cookie-message__container">
+				<div>
 					<p class="o-cookie-message__description">
 						By continuing to use this site you consent to the use of cookies on your device as described in our <a href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">cookie policy</a> unless you have disabled them. You can change your <a href="http://help.ft.com/help/legal-privacy/cookies/how-to-manage-cookies/">cookie settings</a> at any time but parts of our site will not function correctly without them.
 					</p>
@@ -31,6 +32,7 @@ class CookieMessage {
 									<span class="o-cookie-message__close-btn-label">Close</span>
 							</button>
 					</div>
+				</div>
 			</div>`;
 	}
 


### PR DESCRIPTION
This commit removes some erroneous padding which was stopping the
cookie message from lining up with the other items on the page
at small widths (where the gutters are smaller)
This commit also fixes the alignment of the close button to line
up with the other edge of the banner properly.

BEFORE
![before_desktop](https://cloud.githubusercontent.com/assets/68009/19086230/2d943c52-8a65-11e6-9112-2faa5f974aed.png)
![before_mobile pnf](https://cloud.githubusercontent.com/assets/68009/19086240/32eab514-8a65-11e6-9abe-000a6307b433.png)

AFTER
![after_desktop](https://cloud.githubusercontent.com/assets/68009/19086243/3a3275aa-8a65-11e6-8c80-f9719f9069c7.png)
![after_mobile](https://cloud.githubusercontent.com/assets/68009/19086246/3ee2ef8a-8a65-11e6-90ba-2d3169ea7b6a.png)
