### PR TITLE
Fix demo

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,5 +1,21 @@
-import './../../main.js';
+import CookieMessage from './../../main.js';
 
 document.addEventListener('DOMContentLoaded', function() {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
+
+document.addEventListener('oCookieMessage.ready', function() {
+	document.querySelector('[data-o-component="o-cookie-message-close"]').removeEventListener('click', CookieMessage.flagUserAsConsentingToCookies);
+	document.querySelector('[data-o-component="o-cookie-message-close"]').addEventListener('click', showNotification);
+});
+
+function showNotification(){
+	const userNotice =`
+	<div class="o-cookie-message__container">
+		<p class="o-cookie-message__description">
+			<strong>Hello!</strong> normally, clicking that button will hide the cookie message for 3 months. But that would mean you wouldn't be able to see this demo anymore, which might be quite annoying. You can refresh the page to get the proper cookie message back.
+		</p>
+	</div>`;
+	const CookieMessageEl = document.querySelector('[data-o-component="o-cookie-message"]');
+	CookieMessageEl.innerHTML = userNotice;
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,2 +1,6 @@
 $o-cookie-message-is-silent: false;
 @import '../../main';
+
+.o-cookie-message {
+	display: block;
+}

--- a/src/js/cookieMessage.js
+++ b/src/js/cookieMessage.js
@@ -10,6 +10,9 @@ class CookieMessage {
 		this.CookieMessageEl = CookieMessageEl;
 
 		this.setup();
+		let e = new CustomEvent('oCookieMessage.ready', { bubbles: true });
+
+		this.CookieMessageEl.dispatchEvent(e);
 	}
 
 	setup () {


### PR DESCRIPTION
The o-cookie-message demos in the registry don't work at the moment
because you can dismiss them!

This commit:

-- overrides the display: none; on o-cookie-message in the demo sass
so it's always visible
-- Adds an event listener to the button so that if you click it in a
demo it changes the body text to a message about why the cookie banner
hasn't disappeared. This will hopefully stop anyone from thinking the
demo or component is broken because it doesn't disappear.