### PR TITLE
Add tests for standardised Origami component behaviour

### DIFF
--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,0 +1,32 @@
+let sandboxEl;
+
+function createSandbox() {
+	if (document.querySelector('.sandbox')) {
+		sandboxEl = document.querySelector('.sandbox');
+	} else {
+		sandboxEl = document.createElement('div');
+		sandboxEl.setAttribute('class', 'sandbox');
+		document.body.appendChild(sandboxEl);
+	}
+}
+
+function reset() {
+	sandboxEl.innerHTML = '';
+}
+
+function insert(html) {
+	createSandbox();
+	sandboxEl.innerHTML = html;
+}
+
+
+function htmlCode () {
+	const html = `<div class="cookie-message-container"><div data-o-component="o-cookie-message" class='o-cookie-message o-cookie-message--banner-centric'>
+  </div></div>`;
+	insert(html);
+}
+
+export {
+	htmlCode,
+	reset
+ };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -22,7 +22,7 @@ function insert(html) {
 
 function htmlCode () {
 	const html = `<div class="cookie-message-container"><div data-o-component="o-cookie-message" class='o-cookie-message o-cookie-message--banner-centric'>
-  </div></div>`;
+		</div></div>`;
 	insert(html);
 }
 

--- a/test/oCookieMessage.test.js
+++ b/test/oCookieMessage.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha, proclaim, sinon */
 
 //import sinon from 'sinon/pkg/sinon';
-import proclaim from 'proclaim';
+//import proclaim from 'proclaim';
 
-import CookieMessage from './../src/js/cookieMessage';
+//import CookieMessage from './../src/js/cookieMessage';
 
 describe("CookieMessage", () => {
 	it("injects the FT legal cookie message into itself");
@@ -19,7 +19,7 @@ describe("CookieMessage", () => {
 		it("checks the value of COOKIE_CONSENT is within the last three months");
 		it("returns false if there is nothing in COOKIE_CONSENT");
 		it("returns true if dateIsWithinLastThreeMonths(COOKIE_CONSENT) returns true");
-		it("returns false if dateIsWithinLastThreeMonths(COOKIE_CONSENT) returns false")
+		it("returns false if dateIsWithinLastThreeMonths(COOKIE_CONSENT) returns false");
 	});
 
 	describe("flagUserAsConsentingToCookies", () => {

--- a/test/oCookieMessage.test.js
+++ b/test/oCookieMessage.test.js
@@ -6,10 +6,28 @@ import proclaim from 'proclaim';
 import CookieMessage from './../src/js/cookieMessage';
 
 describe("CookieMessage", () => {
-	it('is defined', () => {
-		proclaim.isFunction(CookieMessage);
+	it("injects the FT legal cookie message into itself");
+	it("does not inject the FT legal cookie message if data-o-cookie-message-use-custom-html is present");
+
+	describe("dateIsWithinLastThreeMonths", () => {
+		it("returns true if the date passed in is within the last 3 months");
+		it("returns false if the date passed in is longer than the last three months");
 	});
-	it('has a static init method', () => {
-		proclaim.isFunction(CookieMessage.init);
+
+	describe("userHasConsentedToCookies", () => {
+		it("calls flagUserAsConsentingToCookies if they have consented using the old o-cookies way");
+		it("checks the value of COOKIE_CONSENT is within the last three months");
+		it("returns false if there is nothing in COOKIE_CONSENT");
+		it("returns true if dateIsWithinLastThreeMonths(COOKIE_CONSENT) returns true");
+		it("returns false if dateIsWithinLastThreeMonths(COOKIE_CONSENT) returns false")
+	});
+
+	describe("flagUserAsConsentingToCookies", () => {
+		it("sets a value in localStorage called COOKIE_CONSENT to the result of Date.now");
+		it("calls hideMessage");
+	});
+
+	describe("hideMessage", () => {
+		it("removes the o-cookie-message--active class from the CookieMessageEl");
 	});
 });

--- a/test/origamiComponent.test.js
+++ b/test/origamiComponent.test.js
@@ -1,0 +1,60 @@
+/* eslint-env mocha, sinon, proclaim */
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+
+import * as fixtures from './helpers/fixtures';
+
+const oCookieMessage = require('./../main');
+
+describe("oCookieMessage", () => {
+  beforeEach(() => {
+    fixtures.htmlCode();
+  });
+
+  afterEach(() => {
+    fixtures.reset();
+  });
+
+	it('is defined', () => {
+		proclaim.isFunction(oCookieMessage);
+	});
+
+	it('has a static init method', () => {
+		proclaim.isFunction(oCookieMessage.init);
+	});
+
+	it("should autoinitialize", (done) => {
+		const initSpy = sinon.spy(oCookieMessage, 'init');
+		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+		setTimeout(function(){
+			proclaim.isTrue(initSpy.called);
+			initSpy.restore();
+			done();
+		}, 100);
+	});
+
+	it("should not autoinitialize when the event is not dispached", () => {
+		const initSpy = sinon.spy(oCookieMessage, 'init');
+		proclaim.isFalse(initSpy.called);
+	});
+
+	describe("init", () => {
+		beforeEach(() => {
+      fixtures.htmlCode();
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+		});
+
+		it("should create a sinlge oCookieMessage when no element is passed in", () => {
+			const cookiemessage = oCookieMessage.init();
+			proclaim.equal(cookiemessage instanceof oCookieMessage, true);
+		});
+
+		it("should create an oCookieMessage for the element found within the passed in selector", () => {
+			const cookiemessage = oCookieMessage.init('.cookie-message-container');
+			proclaim.equal(cookiemessage instanceof oCookieMessage, true);
+		});
+	});
+});

--- a/test/origamiComponent.test.js
+++ b/test/origamiComponent.test.js
@@ -7,13 +7,13 @@ import * as fixtures from './helpers/fixtures';
 const oCookieMessage = require('./../main');
 
 describe("oCookieMessage", () => {
-  beforeEach(() => {
-    fixtures.htmlCode();
-  });
+	beforeEach(() => {
+		fixtures.htmlCode();
+	});
 
-  afterEach(() => {
-    fixtures.reset();
-  });
+	afterEach(() => {
+		fixtures.reset();
+	});
 
 	it('is defined', () => {
 		proclaim.isFunction(oCookieMessage);
@@ -40,7 +40,7 @@ describe("oCookieMessage", () => {
 
 	describe("init", () => {
 		beforeEach(() => {
-      fixtures.htmlCode();
+			fixtures.htmlCode();
 		});
 
 		afterEach(() => {


### PR DESCRIPTION
These tests are related to initialisation, and should be very similar for all
Origami components and not specific to oCookieMessage, so I'm putting them in
their own file.

Component specific behaviour can live in oCookieMessgae.test.js