### PR TITLE
Speed up Circle CI execution time by using the cached copy of OBT from the dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,10 @@ machine:
     version: 6
 dependencies:
   override:
-    - ./nodes/modules/.bin/obt install
+    - ./node_modules/.bin/obt install
   cache_directories:
     - "node_modules"
 test:
   override:
-    - ./nodes/modules/.bin/obt test
-    - ./nodes/modules/.bin/obt verify
+    - ./node_modules/.bin/obt test
+    - ./node_modules/.bin/obt verify

--- a/circle.yml
+++ b/circle.yml
@@ -3,14 +3,12 @@ machine:
     - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
   node:
     version: 6
-  post:
-    - npm install -g origami-build-tools
 dependencies:
   override:
-    - obt install
+    - ./nodes/modules/.bin/obt install
   cache_directories:
     - "node_modules"
 test:
   override:
-    - obt test
-    - obt verify
+    - ./nodes/modules/.bin/obt test
+    - ./nodes/modules/.bin/obt verify

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start karma.conf.js"
+    "test": "karma start karma.conf.js"
   },
   "devDependencies": {
     "babel-loader": "^5.3.2",


### PR DESCRIPTION
We have OBT as a dev dependency and we cache the `node_modules` folder, using this cached copy of OBT removes ~2 mintues from the execution time on Circle CI. 