### PR TITLE
use npm and bower directly as can't use obt before it is installed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,11 @@ machine:
     version: 6
 dependencies:
   override:
-    - ./node_modules/.bin/obt install
+    - npm install
+    - bower install
   cache_directories:
     - "node_modules"
+    - "bower_components"
 test:
   override:
     - ./node_modules/.bin/obt test


### PR DESCRIPTION
This came about from my change in #24 