### PR TITLE
Revert "Speed up Circle CI execution time by using the cached copy of OBT from the dependencies"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,12 +3,14 @@ machine:
     - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
   node:
     version: 6
+  post:
+    - npm install -g origami-build-tools
 dependencies:
   override:
-    - ./node_modules/.bin/obt install
+    - obt install
   cache_directories:
     - "node_modules"
 test:
   override:
-    - ./node_modules/.bin/obt test
-    - ./node_modules/.bin/obt verify
+    - obt test
+    - obt verify

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "karma start karma.conf.js"
+    "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "devDependencies": {
     "babel-loader": "^5.3.2",


### PR DESCRIPTION
Reverts Financial-Times/o-cookie-message#24

It seems there was reasoning behind installing obt manually in circle. Circle doesn't have `bower` installed by default.