### PR TITLE
Avoid specifying git protocol

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "o-typography": "^4.3.1",
     "o-grid": "^4.2.3",
     "o-icons": ">=4.4.2 <6",
-    "superstore-sync": "git@github.com:alicebartlett/superstore-sync.git#b29aa99"
+    "superstore-sync": "alicebartlett/superstore-sync#b29aa99"
   }
 }


### PR DESCRIPTION
There's something weird with my local git setup so install fails for me. Bower supports these github shorthands, so may as well use instead @alicebartlett 