### PR TITLE
Updating superstore-sync version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "o-typography": "^4.3.1",
     "o-grid": "^4.2.3",
     "o-icons": ">=4.4.2 <6",
-    "superstore-sync": "git@github.com:alicebartlett/superstore-sync.git#b29aa99"
+    "superstore-sync": "^2.1.1"
   }
 }


### PR DESCRIPTION
Switching back to superstore-sync as Alice's forked changes have been merged back upstream

https://github.com/matthew-andrews/superstore-sync/pull/11