### PR TITLE
Add tabindex of -1 when cookie message is dismissed

### DIFF
--- a/src/js/cookieMessage.js
+++ b/src/js/cookieMessage.js
@@ -48,6 +48,7 @@ class CookieMessage {
 	static hideMessage () {
 		const message = document.querySelector('[data-o-component="o-cookie-message"]');
 		message.classList.remove('o-cookie-message--active');
+		message.setAttribute('tabindex', '-1');
 	}
 
 	static flagUserAsConsentingToCookies () {


### PR DESCRIPTION
Focus was getting lost in the cookie message after it was dismissed