### PR TITLE
stop using overly generic oNormaliseHTML include

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -11,12 +11,23 @@
 	/*------------------------------------*\
 			#BLOCK-DESKTOP
 	\*------------------------------------*/
-	@include oNormaliseHTML;
 
 	.o-cookie-message {
+		margin: 0;
+
+		text-rendering: optimizeLegibility;
+
+		// sass-lint:disable no-vendor-prefixes
+		-ms-text-size-adjust: 100%;
+		-webkit-text-size-adjust: 100%;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		// sass-lint:enable no-vendor-prefixes
+
 		display: none;
 		position: relative;
 		background-color: oColorsGetColorFor(o-cookie-message, background);
+		@include oNormaliseBoxSizing;
 		@include oTypographyPadding($top: 4, $bottom: 4);
 
 		&__container {


### PR DESCRIPTION
<img width="1440" alt="screen shot 2017-06-29 at 12 30 25" src="https://user-images.githubusercontent.com/1569131/27685580-be6aa228-5cc6-11e7-8fd3-af15411e80f0.png">
new version on the left, old version on the right, they should look exactly the same