### PR TITLE
Implements oCookieMessage.accepted event on cookie accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 ```
 
+#### Events
+
+You may listen to two events that bubble out from the oCookieMessage DOM element:-
+
+- `oCookieMessage.ready` is emitted when the component has finished initialising.
+- `oCookieMessage.accepted` is emitted when the user accepts the cookie message. It is not emitted if the user has already accepted cookies. This is intended to be used to allow developers to initialise their tracking logic once the user has given consent.
+
 ### Sass
 
 As with all Origami components, o-cookie-message has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than incorporating its mixins into your own Sass) set `$o-cookie-message-is-silent : false;` in your Sass before you import the o-cookie-message Sass:

--- a/test/oCookieMessage.test.js
+++ b/test/oCookieMessage.test.js
@@ -24,6 +24,13 @@ describe("CookieMessage", () => {
 		proclaim.equal(cookiemessage.CookieMessageEl.innerHTML, oCookieMessage.cookieHTML());
 	});
 
+	it('emits an oCookieMessage.ready event on initialisation', () => {
+		const eventListenerSpy = sinon.spy();
+		document.addEventListener('oCookieMessage.ready', eventListenerSpy);
+		oCookieMessage.init();
+		proclaim.isTrue(eventListenerSpy.called);
+	});
+
 	it("does not inject the FT legal cookie message if data-o-cookie-message-use-custom-html is present", () => {
 		/* remove the standard fixture and use the customCookieMessage fixture */
 		fixtures.reset();
@@ -54,40 +61,39 @@ describe("CookieMessage", () => {
 
 	describe("userHasConsentedToCookies", () => {
 		beforeEach(() => {
-			sinon.spy(oCookieMessage, 'flagUserAsConsentingToCookies');
+			sinon.spy(oCookieMessage, 'setConsentCookieAndHideMessage');
 			sinon.stub(oCookieMessage, "dateIsWithinLastThreeMonths").returns(true);
 		});
 
 		afterEach(() => {
 			oCookieMessage.dateIsWithinLastThreeMonths.restore();
-			oCookieMessage.flagUserAsConsentingToCookies.restore();
+			oCookieMessage.setConsentCookieAndHideMessage.restore();
 			store.local.get.restore();
 		});
 
-
-		it("calls flagUserAsConsentingToCookies if they have consented using the old o-cookies way", () => {
+		it("calls setConsentCookieAndHideMessage if they have consented using the old o-cookies way", () => {
 			/* 1 is the value of the old cookie consent */
 			sinon.stub(store.local, "get").returns("1");
 
 			oCookieMessage.userHasConsentedToCookies();
-			proclaim.isTrue(oCookieMessage.flagUserAsConsentingToCookies.calledOnce);
+			proclaim.isTrue(oCookieMessage.setConsentCookieAndHideMessage.calledOnce);
 
 		});
 
-		it("does not call flagUserAsConsentingToCookies the user has never consented", () => {
+		it("does not call setConsentCookieAndHideMessage the user has never consented", () => {
 			/* null means the cookie message consent has never been set */
 			sinon.stub(store.local, "get").returns(null);
 
 			oCookieMessage.userHasConsentedToCookies();
-			proclaim.isFalse(oCookieMessage.flagUserAsConsentingToCookies.calledOnce);
+			proclaim.isFalse(oCookieMessage.setConsentCookieAndHideMessage.calledOnce);
 		});
 
-		it("does not call flagUserAsConsentingToCookies the user has consented recently", () => {
+		it("does not call setConsentCookieAndHideMessage the user has consented recently", () => {
 			/* set it to 50 seconds ago */
 			sinon.stub(store.local, "get").returns(Date.now()-50);
 
 			oCookieMessage.userHasConsentedToCookies();
-			proclaim.isFalse(oCookieMessage.flagUserAsConsentingToCookies.calledOnce);
+			proclaim.isFalse(oCookieMessage.setConsentCookieAndHideMessage.calledOnce);
 		});
 
 		it("returns false if there is nothing in COOKIE_CONSENT", () => {
@@ -133,6 +139,13 @@ describe("CookieMessage", () => {
 			sinon.spy(oCookieMessage, "hideMessage");
 			oCookieMessage.flagUserAsConsentingToCookies();
 			proclaim.isTrue(oCookieMessage.hideMessage.calledOnce);
+		});
+
+		it('emits an oCookieMessage.accepted event when flagUserAsConsentingToCookies called', () => {
+			const eventListenerSpy = sinon.spy();
+			document.addEventListener('oCookieMessage.accepted', eventListenerSpy);
+			oCookieMessage.flagUserAsConsentingToCookies();
+			proclaim.isTrue(eventListenerSpy.called);
 		});
 	});
 


### PR DESCRIPTION
Also:-
- ✨ *Bonus:* adds missing test for `oCookieMessage.ready` event.
- ✨ *Bonus:* centralising some repeated logic that gets the message element.

Unsolicited feedback:-
- The static vs. instance method split doesn't seem particularly logical to me.  It seems like the module is trying quite hard to be able to support being instantiated multiple times but then not quite managing it.  I've tried to stick to the pattern of everything being a static method.  But is there a long term goal to make it work correctly if instantiated multiple times?