### PR TITLE
Design tweaks

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -76,16 +76,20 @@
 		}
 
 		&__title {
-			@include oTypographySansBold($scale: 0);
+			@include oTypographySansBold($_o-cookie-message-font-scale);
 			color: oColorsGetColorFor(body, text);
 			margin: 0;
 		}
 
 		&__description {
-			@include oTypographySans($scale: 0);
-			padding-right: 15px;
+			@include oTypographySans($_o-cookie-message-font-scale);
+			padding: 15px;
 			margin: 0;
 			color: oColorsGetColorFor(body, text);
+
+			@include oGridRespondTo(L) {
+				width: $_line-width;
+			}
 		}
 
 		a {
@@ -112,6 +116,7 @@
 
 		.o-cookie-message__container {
 			@include oGridContainer();
+
 			> div {
 				position: relative;
 			}

--- a/main.scss
+++ b/main.scss
@@ -46,12 +46,17 @@
 		&__close-btn {
 			position: relative;
 			padding: 0;
+			margin-right: 8px;
 			width: $_o-cookie-message-icon-size + 0px; // Hack to get a `px` at the end
 			height: $_o-cookie-message-icon-size + 0px;
 			border: 0;
 			background: none;
 			cursor: pointer;
 			opacity: 0.8;
+
+			@include oGridRespondTo(M) {
+				margin-right: 0;
+			};
 
 			&:before {
 				@include oIconsGetIcon(cross, oColorsGetColorFor(body, text), $_o-cookie-message-icon-size, $iconset-version: 1);
@@ -83,7 +88,7 @@
 
 		&__description {
 			@include oTypographySans($_o-cookie-message-font-scale);
-			padding: 15px;
+			padding: 0 20px 0 5px;
 			margin: 0;
 			color: oColorsGetColorFor(body, text);
 

--- a/src/js/cookieMessage.js
+++ b/src/js/cookieMessage.js
@@ -37,7 +37,7 @@ class CookieMessage {
 			<div id="o-cookie-message" class="o-cookie-message__container">
 				<div>
 					<p class="o-cookie-message__description">
-						By continuing to use this site you consent to the use of cookies on your device as described in our <a href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">cookie policy</a> unless you have disabled them. You can change your <a href="http://help.ft.com/help/legal-privacy/cookies/how-to-manage-cookies/">cookie settings</a> at any time but parts of our site will not function correctly without them.
+						By continuing to use this site you consent to the use of cookies on your device as described in our <a href="http://help.ft.com/tools-services/how-the-ft-manages-cookies-on-its-websites/">Cookie Policy</a> unless you have disabled them. You can change your <a href="http://help.ft.com/help/legal-privacy/cookies/how-to-manage-cookies/">Cookie Settings</a> at any time but parts of our site will not function correctly without them.
 					</p>
 					<div class="o-cookie-message__close-btn-container">
 							<button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close" aria-controls="o-cookie-message">

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,6 +1,6 @@
 $o-cookie-message-is-silent: true !default;
 $_o-cookie-message-icon-size: 25;
 $_o-cookie-message-font-scale: 0;
-$_characters-per-line: 80; //~25 words
+$_characters-per-line: 85; //~25 words
 $_golden-ratio: 1.618;
 $_line-width: (_oTypographyFontSizeFromScale($_o-cookie-message-font-scale) / $_golden-ratio) * $_characters-per-line;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,2 +1,6 @@
 $o-cookie-message-is-silent: true !default;
 $_o-cookie-message-icon-size: 25;
+$_o-cookie-message-font-scale: 0;
+$_characters-per-line: 80; //~25 words
+$_golden-ratio: 1.618;
+$_line-width: (_oTypographyFontSizeFromScale($_o-cookie-message-font-scale) / $_golden-ratio) * $_characters-per-line;


### PR DESCRIPTION
Addresses the tweaks requested in https://github.com/Financial-Times/o-cookie-message/issues/48

Desktop before:
![screen shot 2018-01-12 at 14 21 34](https://user-images.githubusercontent.com/16777943/34879088-09974fe4-f7a4-11e7-8a49-22108dde367c.png)
Desktop after
![screen shot 2018-01-12 at 14 21 28](https://user-images.githubusercontent.com/16777943/34879115-1cc5d388-f7a4-11e7-93b5-50f294aac1f8.png)

Mobile before
![screen shot 2018-01-12 at 14 21 45](https://user-images.githubusercontent.com/16777943/34879132-2a618528-f7a4-11e7-8ed6-a85e24bec883.png)

Mobile after
![screen shot 2018-01-12 at 14 22 10](https://user-images.githubusercontent.com/16777943/34879142-2f6afde2-f7a4-11e7-935e-cff8d1c69d43.png)

Closes #48 
