### PR TITLE
Provide better domain defaults

### DIFF
--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -3,7 +3,10 @@ const Banner = require('o-banner/src/js/banner');
 class CookieMessage {
 
 	static get defaultOptions() {
-		const domain = window.location.hostname.replace('www.', '');
+		let domain = 'ft.com';
+		if (!/\.ft\.com$/i.test(window.location.hostname)) {
+			domain = window.location.hostname.replace('www.', '');
+		}
 		const redirect = window.location.href;
 		return {
 			cookieMessageClass: 'o-cookie-message',


### PR DESCRIPTION
This caters for more of the FT's domains, specifically better catering
for sites which live on a subdomain of `ft.com`. so:

  - `www.ft.com` defaults to `ft.com`
  - `ftalphaville.ft.com` defaults to `ft.com`
  - `www.thebanker.com` defaults to `thebanker.com`