### PR TITLE
use correct path for manage cookies page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -8,7 +8,7 @@ class CookieMessage {
 	static get defaultOptions() {
 		let domain = 'ft.com';
 		if (!/\.ft\.com$/i.test(window.location.hostname)) {
-      // replace www or subdomain
+			// replace www or subdomain
 			domain = window.location.hostname.replace(/^(.*?)\./, '');
 		}
 		const redirect = window.location.href;

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -16,7 +16,6 @@ class CookieMessage {
 			cookieMessageClass: 'o-cookie-message',
 			theme: null,
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
-			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie`,
 			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,
 			consentCookieName: 'FTCookieConsentGDPR',
 
@@ -84,7 +83,7 @@ class CookieMessage {
 					</p>
 				`,
 				buttonLabel: 'Accept & continue',
-				buttonUrl: this.options.acceptUrlFallback,
+				buttonUrl: this.options.acceptUrl,
 				linkLabel: 'Manage cookies',
 				linkUrl: this.options.manageCookiesUrl
 			});

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -8,15 +8,16 @@ class CookieMessage {
 	static get defaultOptions() {
 		let domain = 'ft.com';
 		if (!/\.ft\.com$/i.test(window.location.hostname)) {
-			domain = window.location.hostname.replace('www.', '');
+      // replace www or subdomain
+			domain = window.location.hostname.replace(/^(.*?)\./, '');
 		}
 		const redirect = window.location.href;
 		return {
 			cookieMessageClass: 'o-cookie-message',
 			theme: null,
-			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie`,
-			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
-			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,
+			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
+			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie`,
+			manageCookiesUrl: 'https://www.ft.com/preferences/manage-cookies',
 			consentCookieName: 'FTCookieConsentGDPR',
 
 			//TODO: remove when time is up — https://github.com/Financial-Times/o-cookie-message/issues/65

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -17,7 +17,7 @@ class CookieMessage {
 			theme: null,
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
 			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie`,
-			manageCookiesUrl: 'https://www.ft.com/preferences/manage-cookies',
+			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,
 			consentCookieName: 'FTCookieConsentGDPR',
 
 			//TODO: remove when time is up — https://github.com/Financial-Times/o-cookie-message/issues/65

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -16,7 +16,7 @@ class CookieMessage {
 			theme: null,
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie`,
 			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
-			manageCookiesUrl: 'https://www.ft.com/preferences/manage-cookies',
+			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,
 			consentCookieName: 'FTCookieConsentGDPR',
 
 			//TODO: remove when time is up — https://github.com/Financial-Times/o-cookie-message/issues/65

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -14,8 +14,9 @@ class CookieMessage {
 		const redirect = window.location.href;
 		return {
 			cookieMessageClass: 'o-cookie-message',
-			theme: null,
-			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
+      theme: null,
+			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
+			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
 			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,
 			consentCookieName: 'FTCookieConsentGDPR',
 
@@ -83,7 +84,7 @@ class CookieMessage {
 					</p>
 				`,
 				buttonLabel: 'Accept & continue',
-				buttonUrl: this.options.acceptUrl,
+				buttonUrl: this.options.acceptUrlFallback,
 				linkLabel: 'Manage cookies',
 				linkUrl: this.options.manageCookiesUrl
 			});

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -14,7 +14,7 @@ class CookieMessage {
 		const redirect = window.location.href;
 		return {
 			cookieMessageClass: 'o-cookie-message',
-      theme: null,
+			theme: null,
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
 			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
 			manageCookiesUrl: `https://cookies.${domain}/preferences/manage-cookies`,

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -55,7 +55,7 @@ export const html = {
 					</div>
 
 			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="https://www.ft.com/preferences/manage-cookies" class="o-cookie-message__link">Manage cookies</a>
+				<a href="https://cookies.localhost/preferences/manage-cookies" class="o-cookie-message__link">Manage cookies</a>
 			</div>
 
 				</div>
@@ -85,7 +85,7 @@ export const html = {
 					</div>
 
 			<div class="o-cookie-message__action o-cookie-message__action--secondary">
-				<a href="https://www.ft.com/preferences/manage-cookies" class="o-cookie-message__link">Manage cookies</a>
+				<a href="https://cookies.localhost/preferences/manage-cookies" class="o-cookie-message__link">Manage cookies</a>
 			</div>
 
 				</div>


### PR DESCRIPTION
So that it works with specialist titles not on the ft.com domain:
- change manage cookies path
- switch the fallback accept around with the default accept url
- replace using a RegEx, so we are covered for subdomains as well as www