### PR TITLE
say goodbye to banner, 🍪!

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,10 +13,11 @@
     "main.js"
   ],
   "dependencies": {
-    "o-banner": "^2.1.2",
     "superstore-sync": "^2.1.1",
     "o-viewport": "^3.1.5",
     "o-spacing": "^2.0.0",
-    "o-typography": "^5.0.0"
+    "o-typography": "^5.0.0",
+    "o-visual-effects": "^2.1.0",
+    "o-buttons": "^5.0.0"
   }
 }

--- a/demos/src/cookie-message.mustache
+++ b/demos/src/cookie-message.mustache
@@ -1,2 +1,1 @@
-
 <div data-o-component="o-cookie-message"></div>

--- a/demos/src/custom-html-full.mustache
+++ b/demos/src/custom-html-full.mustache
@@ -1,10 +1,9 @@
-
 <div data-o-component="o-cookie-message" class="o-cookie-message">
 	<div class="o-cookie-message__outer">
 		<div class="o-cookie-message__inner" data-o-banner-inner="">
 			<div class="o-cookie-message__content">
 
-				<header class="${cookieMessageClass}__heading">
+				<header class="o-cookie-message__heading">
 					<h1>Custom Cookie Message</h1>
 				</header>
 				<p>

--- a/main.scss
+++ b/main.scss
@@ -1,7 +1,7 @@
 @import "o-typography/main";
 @import "o-spacing/main";
-@import "o-banner/main";
-
+@import "o-visual-effects/main";
+@import "o-buttons/main";
 @import "src/scss/color-use-cases";
 @import "src/scss/variables";
 @import "src/scss/mixins";

--- a/origami.json
+++ b/origami.json
@@ -10,7 +10,11 @@
 		"slack": "financialtimes/ft-origami"
 	},
 	"supportStatus": "active",
-	"browserFeatures": {},
+	"browserFeatures": {
+		"required": [
+			"Element.prototype.classList"
+		]
+	},
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-cookie-message"
 	},

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -1,5 +1,3 @@
-import Banner from 'o-banner/src/js/banner';
-
 class CookieMessage {
 	static get defaultOptions() {
 		let domain = 'ft.com';
@@ -11,7 +9,6 @@ class CookieMessage {
 		}
 		const redirect = window.location.href;
 		return {
-			cookieMessageClass: 'o-cookie-message',
 			theme: null,
 			acceptUrl: `https://consent.${domain}/__consent/consent-record-cookie?cookieDomain=.${domain}`,
 			acceptUrlFallback: `https://consent.${domain}/__consent/consent-record-cookie?redirect=${redirect}&cookieDomain=.${domain}`,
@@ -41,41 +38,34 @@ class CookieMessage {
 	}
 
 	createCookieMessage() {
-		if (!this.banner) {
-			this.banner = new Banner(this.cookieMessageElement, {
-				autoOpen: true,
-				suppressCloseButton: true,
-				theme: this.options.theme,
-				bannerClass: this.options.cookieMessageClass,
-				bannerClosedClass: `${this.options.cookieMessageClass}--closed`,
-				outerClass: `${this.options.cookieMessageClass}__outer`,
-				innerClass: `${this.options.cookieMessageClass}__inner`,
-				contentClass: `${this.options.cookieMessageClass}__content`,
-				contentLongClass: `${this.options.cookieMessageClass}__content--long`,
-				contentShortClass: `${this.options.cookieMessageClass}__content--short`,
-				actionsClass: `${this.options.cookieMessageClass}__actions`,
-				actionClass: `${this.options.cookieMessageClass}__action`,
-				actionSecondaryClass: `${
-					this.options.cookieMessageClass
-				}__action--secondary`,
-				buttonClass: `${this.options.cookieMessageClass}__button`,
-				linkClass: `${this.options.cookieMessageClass}__link`,
-				contentLong: `
-					<header class="${this.options.cookieMessageClass}__heading">
-						<h1>Cookies on the FT</h1>
-					</header>
-					<p>
-						We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
-						for a number of reasons, such as keeping FT Sites reliable and secure, personalising
-						content and ads, providing social media features and to analyse how our Sites are used.
-					</p>
-				`,
-				buttonLabel: 'Accept & continue',
-				buttonUrl: this.options.acceptUrlFallback,
-				linkLabel: 'Manage cookies',
-				linkUrl: this.options.manageCookiesUrl
-			});
-		}
+		this.cookieMessageElement.innerHTML = `
+<div class="o-cookie-message__outer">
+	<div class="o-cookie-message__inner">
+		<div class="o-cookie-message__content">
+			<header class="o-cookie-message__heading">
+				<h1>Cookies on the FT</h1>
+			</header>
+			<p>
+				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
+				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
+				content and ads, providing social media features and to analyse how our Sites are used.
+			</p>
+		</div>
+		<div class="o-cookie-message__actions">
+
+			<div class="o-cookie-message__action">
+				<a href="${this.options.acceptUrlFallback}" class="o-cookie-message__button">
+					Accept &amp; continue
+				</a>
+			</div>
+
+			<div class="o-cookie-message__action o-cookie-message__action--secondary">
+				<a href="${this.options.manageCookiesUrl}" class="o-cookie-message__link">Manage cookies</a>
+			</div>
+		</div>
+	</div>
+</div>
+`;
 	}
 
 	/**
@@ -84,7 +74,7 @@ class CookieMessage {
 	 */
 	updateConsent() {
 		const button = document.querySelector(
-			`.${this.banner.options.buttonClass}`
+			`.o-cookie-message__button`
 		);
 		if (button) {
 			button.addEventListener('click', e => {
@@ -111,8 +101,16 @@ class CookieMessage {
 	 */
 	showCookieMessage() {
 		this.cookieMessageElement.classList.add(
-			`${this.options.cookieMessageClass}--active`
+			'o-cookie-message',
+			'o-cookie-message--active'
 		);
+
+		if (this.options.theme) {
+			this.cookieMessageElement.classList.add(
+				`o-cookie-message--${this.options.theme}`
+			);
+		}
+
 		this.dispatchEvent('oCookieMessage.view');
 		this.updateConsent();
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -36,36 +36,23 @@
 	}
 
 	.o-cookie-message__outer {
+		@include oVisualEffectsShadowsElevation('high');
 		background: oColorsGetPaletteColor('white');
 		color: oColorsGetPaletteColor('black');
-		@include oVisualEffectsShadowsElevation('high');
 	}
 
 	.o-cookie-message__inner {
-		@include oTypographySans($scale: 2);
+		@include oVisualEffectsShadowsElevation('high');
+		@include oTypographySans($scale: 0);
 		// sass-lint:disable no-vendor-prefixes
 		-webkit-font-smoothing: antialiased;
 		// sass-lint:enable no-vendor-prefixes
 		position: relative;
-		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		max-width: map-get($o-grid-layouts, XL);
 		margin: 0 auto;
-		padding: $_o-cookie-message-spacing 0;
 		box-sizing: border-box;
-
-		@include oGridRespondTo($until: S) {
-			@include oTypographySans($scale: 0);
-			display: block;
-			padding: $_o-cookie-message-spacing;
-			padding-top: oSpacingByIncrement(7);
-		}
-
 		background: white;
-
-		@include oVisualEffectsShadowsElevation('high');
-		@include oTypographySans($scale: 0);
 		display: block;
 		padding: $_o-cookie-message-spacing;
 		padding-top: oSpacingByIncrement(7);
@@ -133,9 +120,9 @@
 	.o-cookie-message {
 		.o-cookie-message__heading {
 			h1 {
-				margin-bottom: 0;
 				@include oTypographySans($scale: 3);
 				@include oTypographyBold($font: 'sans');
+				margin-bottom: 0;
 			}
 			&:after {
 				content: '';

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,36 +1,102 @@
 // Base cookie message styles
 @mixin _oCookieMessageBase() {
 	.o-cookie-message {
-		@include oBannerBase;
-		@include oBannerThemeCompactBase;
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		display: block;
+		width: 100%;
+		margin: 0;
+
+		@include oGridRespondTo(S) {
+			width: oGridColspan(7);
+			margin: $_o-cookie-message-spacing / 2;
+		}
+
+		@include oGridRespondTo(M) {
+			width: oGridColspan(6);
+		}
+
+		@include oGridRespondTo(L) {
+			width: oGridColspan(5);
+		}
+
+		@include oGridRespondTo(XL) {
+			width: map-get($o-grid-layouts, XL) / 2.5; // width is 40% grid
+			left: calc((100vw - #{map-get($o-grid-layouts, XL)}) / 2); // ((viewport - grid width) / 2)
+		}
 	}
 
 	.o-cookie-message--active {
 		display: block;
 	}
 
-	o-cookie-message--closed {
-		@include oBannerClosed;
+	.o-cookie-message--closed {
+		display: none;
 	}
 
-	o-cookie-message__outer {
-		@include oBannerOuter;
-		@include oBannerThemeCompactOuter;
+	.o-cookie-message__outer {
+		background: oColorsGetPaletteColor('white');
+		color: oColorsGetPaletteColor('black');
+		@include oVisualEffectsShadowsElevation('high');
 	}
 
-	o-cookie-message__inner {
-		@include oBannerInner;
-		@include oBannerThemeCompactInner;
+	.o-cookie-message__inner {
+		@include oTypographySans($scale: 2);
+		// sass-lint:disable no-vendor-prefixes
+		-webkit-font-smoothing: antialiased;
+		// sass-lint:enable no-vendor-prefixes
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		max-width: map-get($o-grid-layouts, XL);
+		margin: 0 auto;
+		padding: $_o-cookie-message-spacing 0;
+		box-sizing: border-box;
+
+		@include oGridRespondTo($until: S) {
+			@include oTypographySans($scale: 0);
+			display: block;
+			padding: $_o-cookie-message-spacing;
+			padding-top: oSpacingByIncrement(7);
+		}
+
+		background: white;
+
+		@include oVisualEffectsShadowsElevation('high');
+		@include oTypographySans($scale: 0);
+		display: block;
+		padding: $_o-cookie-message-spacing;
+		padding-top: oSpacingByIncrement(7);
+		max-width: none;
 	}
 
-	o-cookie-message__content {
-		@include oBannerContent;
-		@include oBannerThemeCompactContent;
+	.o-cookie-message__content {
+		padding: 0;
+
+		p {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+
+		h1 {
+			@include oTypographySans($scale: 0);
+		}
+
+		@include oGridRespondTo($until: M) {
+			&,
+			h1 {
+				@include oTypographySans($scale: 0);
+			}
+		}
 	}
 
-	o-cookie-message__actions {
-		@include oBannerActions;
-		@include oBannerThemeCompactActions;
+	.o-cookie-message__actions {
+		@include oTypographySans($scale: 2);
+		display: flex;
+		align-items: center;
+		margin-top: oSpacingByName('s6');
 		flex-direction: row-reverse;
 		justify-content: space-between;
 
@@ -38,7 +104,6 @@
 			flex-direction: column-reverse;
 			align-items: flex-start;
 			margin-top: 0;
-
 			.o-cookie-message__action {
 				align-self: stretch;
 
@@ -50,14 +115,16 @@
 		}
 	}
 
-	o-cookie-message__action {
-		@include oBannerAction;
-		@include oBannerThemeCompactAction;
+	.o-cookie-message__action {
 		padding: 0;
 	}
 
-	o-cookie-message__button {
-		@include oBannerButton;
+	.o-cookie-message__button {
+		@include oButtons(
+			$size: 'big',
+			$theme: 'primary'
+		);
+		white-space: nowrap;
 	}
 }
 
@@ -65,17 +132,54 @@
 @mixin _oCookieMessageStandard() {
 	.o-cookie-message {
 		.o-cookie-message__heading {
-			@include oBannerHeading;
-			@include oBannerThemeCompactHeading;
+			h1 {
+				margin-bottom: 0;
+				@include oTypographySans($scale: 3);
+				@include oTypographyBold($font: 'sans');
+			}
+			&:after {
+				content: '';
+				display: block;
+				width: 100px;
+				margin-top: oSpacingByName('s2');
+				margin-bottom: oSpacingByName('s4');
+
+				border-bottom: oSpacingByIncrement(2) solid;
+				border-color: oColorsGetPaletteColor('teal');
+			}
+
+			@include oTypographySans($scale: 3);
+			padding-right: $_o-cookie-message-spacing;
+
+			@include oGridRespondTo($until: M) {
+				&,
+				h1 {
+					@include oTypographySans($scale: 2);
+				}
+			}
+			&:after {
+				margin-top: oSpacingByName('s2');
+				margin-bottom: oSpacingByName('s3');
+				width: 60px;
+				border-bottom-width: oSpacingByIncrement(1);
+			}
 		}
 
 		.o-cookie-message__action--secondary {
-			@include oBannerActionSecondary;
-			@include oBannerThemeCompactActionSecondary;
+			@include oGridRespondTo($until: M) {
+				margin-top: $_o-cookie-message-spacing / 4;
+			}
 		}
 
 		.o-cookie-message__link {
-			@include oBannerLink;
+			@include oTypographyLinkCustom(
+				$baseColor: 'teal',
+				$hoverColor: 'teal',
+				$outlineColor: 'teal',
+				$backgroundColor: 'white'
+			);
+			@include oTypographySans($scale: 0);
+			white-space: nowrap;
 		}
 
 		.o-cookie-message__link--external {
@@ -85,10 +189,10 @@
 		.o-cookie-message__link--external,
 		.o-cookie-message__link {
 			@include oTypographyLinkCustom(
-				$baseColor: oColorsGetUseCase('link', 'text'),
-				$hoverColor: oColorsGetUseCase('link', 'text'),
-				$outlineColor: oColorsGetUseCase('link', 'text'),
-				$backgroundColor: oColorsGetUseCase('o-banner', 'background')
+				$baseColor: 'teal',
+				$hoverColor: 'teal',
+				$outlineColor: 'teal',
+				$backgroundColor: 'white'
 			);
 		}
 	}
@@ -105,7 +209,7 @@
 				background: oColorsGetUseCase(o-cookie-message-alternative-button, text),
 				hover: oColorsGetUseCase(o-cookie-message-alternative-button, hover),
 				colorizer: primary
-			))
+			));
 		}
 
 		.o-cookie-message__heading:after {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,3 +1,4 @@
 $o-cookie-message-is-silent: true !default;
 
+$_o-cookie-message-spacing: oSpacingByIncrement(10);
 $_o-cookie-message-themes: ('standard', 'alternative');

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -34,7 +34,7 @@ export const html = {
 	</div>`,
 	imperativeCookieMessage: `<div data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active">
 		<div class="o-cookie-message__outer">
-			<div class="o-cookie-message__inner" data-o-banner-inner="">
+			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">
 
@@ -62,9 +62,9 @@ export const html = {
 			</div>
 		</div>
 	</div>`,
-	imperativeAltCookieMessage: `<div data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--alternative o-cookie-message--active">
+	imperativeAltCookieMessage: `<div data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active o-cookie-message--alternative">
 		<div class="o-cookie-message__outer">
-			<div class="o-cookie-message__inner" data-o-banner-inner="">
+			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">
 


### PR DESCRIPTION
Previously, o-cookie-message used o-banner in a way that is no longer
possible.

sasswise: obanner now provides only a Primary Mixin and doesn't allow the
granular use that was being taken advantage of by o-cookie-message.

jswise: o-banner was being used to generate the html, that has now been replaced by 1
big chunk of innerHTML setting instead.
