### PR TITLE
Append created div if no element was passed

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -12,7 +12,8 @@
 	"supportStatus": "active",
 	"browserFeatures": {
 		"required": [
-			"Element.prototype.classList"
+			"Element.prototype.classList",
+			"Element.prototype.append"
 		]
 	},
 	"ci": {

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -18,7 +18,12 @@ class CookieMessage {
 	}
 
 	constructor(cookieMessageElement, options) {
-		this.cookieMessageElement = cookieMessageElement || document.createElement("div");
+		if (cookieMessageElement === null || cookieMessageElement === undefined) {
+			cookieMessageElement = document.createElement("div");
+			document.body.append(cookieMessageElement);
+		}
+
+		this.cookieMessageElement = cookieMessageElement;
 
 		// Set cookie message options
 		this.options = Object.assign(
@@ -201,6 +206,7 @@ class CookieMessage {
 		const cookieMessageElement = rootElement.querySelector(
 			'[data-o-component="o-cookie-message"]'
 		);
+
 		return new CookieMessage(cookieMessageElement, options);
 	}
 }


### PR DESCRIPTION
It turns out, in fact, that the previous version of this component allowed
itself to be used without any template at all. Sure, the javascript didn't work
and it wasn't documented at all but we don't know that someone isn't using that
feature and seeing as this is a legal requirement it's probably best to not
change its behaviour during a crunchy time.
