### PR TITLE
Replace the cookie message heading with a `h2`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ The default behaviour for this component is to populate any div with a `data-o-c
 If you need a different message, this can be added with HTML of your choosing. For example:
 ```html
 <div data-o-component="o-cookie-message">
-	<header>
-		<h2>My Cookies</h2>
-	</header>
+	<h2>My Cookies</h2>
 	<p>A message about those specific cookies, here.</p>
 </div>
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you need a different message, this can be added with HTML of your choosing. F
 ```html
 <div data-o-component="o-cookie-message">
 	<header>
-		<h1>My Cookies</h1>
+		<h2>My Cookies</h2>
 	</header>
 	<p>A message about those specific cookies, here.</p>
 </div>

--- a/demos/src/custom-html-full.mustache
+++ b/demos/src/custom-html-full.mustache
@@ -4,7 +4,7 @@
 			<div class="o-cookie-message__content">
 
 				<header class="o-cookie-message__heading">
-					<h1>Custom Cookie Message</h1>
+					<h2>Custom Cookie Message</h2>
 				</header>
 				<p>
 					We use cookies on the FT.

--- a/demos/src/custom-html-full.mustache
+++ b/demos/src/custom-html-full.mustache
@@ -2,10 +2,9 @@
 	<div class="o-cookie-message__outer">
 		<div class="o-cookie-message__inner" data-o-banner-inner="">
 			<div class="o-cookie-message__content">
-
-				<header class="o-cookie-message__heading">
+				<div class="o-cookie-message__heading">
 					<h2>Custom Cookie Message</h2>
-				</header>
+				</div>
 				<p>
 					We use cookies on the FT.
 				</p>

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -65,9 +65,9 @@ class CookieMessage {
 </div>`;
 
 		const defaultContent = `
-<header class="o-cookie-message__heading">
+<div class="o-cookie-message__heading">
 	<h2>Cookies on the FT</h2>
-</header>
+</div>
 <p>
 	We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.
 </p>`;

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -66,7 +66,7 @@ class CookieMessage {
 
 		const defaultContent = `
 <header class="o-cookie-message__heading">
-	<h1>Cookies on the FT</h1>
+	<h2>Cookies on the FT</h2>
 </header>
 <p>
 	We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -67,15 +67,12 @@
 			margin-bottom: 0;
 		}
 
+		// Styling h1 elements within cookie message content
+		// is redundant but may be relied upon by users who
+		// have chosen to use custom markup.
+		// @breaking - remove `.o-cookie-message__content h1` styles
 		h1 {
 			@include oTypographySans($scale: 0);
-		}
-
-		@include oGridRespondTo($until: M) {
-			&,
-			h1 {
-				@include oTypographySans($scale: 0);
-			}
 		}
 	}
 
@@ -118,36 +115,29 @@
 // Standard cookie message styles (for master brand e.g. FT.com)
 @mixin _oCookieMessageStandard() {
 	.o-cookie-message {
+		// default headings used to include a h1,
+		// so style for backward compatibility for users with custom cookie message markup
+		.o-cookie-message__heading,
+		.o-cookie-message__heading h1,
+		.o-cookie-message__heading h2 {
+			@include oTypographySans(
+				$scale: ('default': 2, 'M': 3),
+				$weight: 'semibold'
+			);
+			margin: 0;
+		}
+
 		.o-cookie-message__heading {
-			h1 {
-				@include oTypographySans($scale: 3, $weight: 'semibold');
-				margin: 0;
-			}
+			padding-right: $_o-cookie-message-spacing;
+
 			&:after {
 				content: '';
 				display: block;
-				width: 100px;
-				margin-top: oSpacingByName('s2');
-				margin-bottom: oSpacingByName('s4');
-
-				border-bottom: oSpacingByIncrement(2) solid;
-				border-color: oColorsByName('teal');
-			}
-
-			@include oTypographySans($scale: 3);
-			padding-right: $_o-cookie-message-spacing;
-
-			@include oGridRespondTo($until: M) {
-				&,
-				h1 {
-					@include oTypographySans($scale: 2);
-				}
-			}
-			&:after {
+				width: 60px;
 				margin-top: oSpacingByName('s2');
 				margin-bottom: oSpacingByName('s3');
-				width: 60px;
-				border-bottom-width: oSpacingByIncrement(1);
+				border-bottom: oSpacingByIncrement(1) solid;
+				border-color: oColorsByName('teal');
 			}
 		}
 

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -39,7 +39,7 @@ export const html = {
 			<div class="o-cookie-message__content">
 
 			<header class="o-cookie-message__heading">
-				<h1>Cookies on the FT</h1>
+				<h2>Cookies on the FT</h2>
 			</header>
 			<p>
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
@@ -69,7 +69,7 @@ export const html = {
 			<div class="o-cookie-message__content">
 
 			<header class="o-cookie-message__heading">
-				<h1>Cookies on the FT</h1>
+				<h2>Cookies on the FT</h2>
 			</header>
 			<p>
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -38,9 +38,9 @@ export const html = {
 
 			<div class="o-cookie-message__content">
 
-			<header class="o-cookie-message__heading">
+			<div class="o-cookie-message__heading">
 				<h2>Cookies on the FT</h2>
-			</header>
+			</div>
 			<p>
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
@@ -68,9 +68,9 @@ export const html = {
 
 			<div class="o-cookie-message__content">
 
-			<header class="o-cookie-message__heading">
+			<div class="o-cookie-message__heading">
 				<h2>Cookies on the FT</h2>
-			</header>
+			</div>
 			<p>
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising


### PR DESCRIPTION
The current markup suggests "Cookies on the FT" is the heading of the page 😬 
https://github.com/Financial-Times/o-cookie-message/issues/101