### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/oCookieMessage.test.js
+++ b/test/oCookieMessage.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
+/* global proclaim */
 
 import * as fixtures from './helpers/fixtures';
 import CookieMessage from './../src/js/cookie-message';

--- a/test/origamiComponent.test.js
+++ b/test/origamiComponent.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim sinon */
+
 import * as fixtures from './helpers/fixtures';
 import oCookieMessage from '../main';
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.