### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import CookieMessage from './src/js/cookie-message';
+import CookieMessage from './src/js/cookie-message.js';
 
 function constructAll () {
 	CookieMessage.init();

--- a/test/oCookieMessage.test.js
+++ b/test/oCookieMessage.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import * as fixtures from './helpers/fixtures';
-import CookieMessage from './../src/js/cookie-message';
+import * as fixtures from './helpers/fixtures.js';
+import CookieMessage from './../src/js/cookie-message.js';
 
 const flatten = string => string.replace(/\s/g, '');
 

--- a/test/origamiComponent.test.js
+++ b/test/origamiComponent.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import oCookieMessage from '../main';
+import * as fixtures from './helpers/fixtures.js';
+import oCookieMessage from '../main.js';
 
 describe("oCookieMessage", () => {
 	beforeEach(() => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing