### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -177,8 +177,8 @@ class CookieMessage {
 			return {};
 		}
 		return Object.keys(cookieMessageElement.dataset).reduce((options, key) => {
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oCookieMessage(\w)(\w+)$/)) {
 				return options;
 			}
 


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214