### PR TITLE
Remove the standard theme option (move to base styles).

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ You must either construct an `o-cookie-message` object or fire the `o.DOMContent
 
 ### Constructing an o-cookie-message
 
-There are two available variations of o-cookie-message: `standard` and `alternative`.
+There are two available variations of o-cookie-message the default (standard) cookie message and `alternative`.
 
-If you would like to initialise a `standard` cookie message, you will need to implement the following:
+If you would like to initialise a standard cookie message, you will need to implement the following:
 
 ```js
 import oCookieMessage from 'o-cookie-message';
@@ -127,19 +127,21 @@ Include all themes:
 @include oCookieMessage();
 ```
 
-Include only the [`standard`](https://registry.origami.ft.com/components/o-cookie-message#demo-approved-cookie-banner) theme:
+Include only the [default cookie message](https://registry.origami.ft.com/components/o-cookie-message#demo-approved-cookie-banner):
 
 ```scss
 @include oCookieMessage($opts: (
-  $themes: ('standard')
+	'themes': ()
 ));
 ```
 
-Include only the [`alternative`](https://registry.origami.ft.com/components/o-cookie-message#demo-approved-alternative-cookie-banner) theme:
+_Note: "standard" used to be required as a theme option to output the default theme, this is now output by default without any themes set._
+
+Include the [`alternative` cookie message theme](https://registry.origami.ft.com/components/o-cookie-message#demo-approved-alternative-cookie-banner):
 
 ```scss
 @include oCookieMessage($opts: (
-  $themes: ('alternative')
+	'themes': ('alternative')
 ));
 ```
 

--- a/main.scss
+++ b/main.scss
@@ -26,8 +26,6 @@
 	@each $theme in $themes {
 		@if not index($_o-cookie-message-themes, $theme) {
 			@error "There is no theme '#{$theme}' available in o-cookie-message, please use one of the following: #{$_o-cookie-message-themes}.";
-		} @else if $theme == 'standard' {
-			@include _oCookieMessageStandard();
 		} @else if $theme == 'alternative' {
 			@include _oCookieMessageAlternative();
 		}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,5 +1,11 @@
 // Base cookie message styles
 @mixin _oCookieMessageBase() {
+	$link-theme: (
+		'base': 'teal',
+		'hover': 'teal',
+		'context': 'white'
+	);
+
 	.o-cookie-message {
 		position: fixed;
 		bottom: 0;
@@ -76,6 +82,33 @@
 		}
 	}
 
+	.o-cookie-message__heading {
+		padding-right: $_o-cookie-message-spacing;
+
+		&:after {
+			content: '';
+			display: block;
+			width: 60px;
+			margin-top: oSpacingByName('s2');
+			margin-bottom: oSpacingByName('s3');
+			border-bottom: oSpacingByIncrement(1) solid;
+			border-color: oColorsByName('teal');
+		}
+	}
+
+	// default headings used to include a h1,
+	// so style for backward compatibility for users with custom cookie message markup
+	.o-cookie-message__heading,
+	.o-cookie-message__heading h1,
+	.o-cookie-message__heading h2 {
+		@include oTypographySans(
+			$scale: ('default': 2, 'M': 3),
+			$weight: 'semibold'
+		);
+		margin: 0;
+	}
+
+
 	.o-cookie-message__actions {
 		@include oTypographySans($scale: 2);
 		display: flex;
@@ -99,6 +132,12 @@
 		}
 	}
 
+	.o-cookie-message__action--secondary {
+		@include oGridRespondTo($until: M) {
+			margin-top: $_o-cookie-message-spacing / 4;
+		}
+	}
+
 	.o-cookie-message__action {
 		padding: 0;
 	}
@@ -110,69 +149,22 @@
 		));
 		white-space: nowrap;
 	}
-}
 
-// Standard cookie message styles (for master brand e.g. FT.com)
-@mixin _oCookieMessageStandard() {
-	.o-cookie-message {
-		// default headings used to include a h1,
-		// so style for backward compatibility for users with custom cookie message markup
-		.o-cookie-message__heading,
-		.o-cookie-message__heading h1,
-		.o-cookie-message__heading h2 {
-			@include oTypographySans(
-				$scale: ('default': 2, 'M': 3),
-				$weight: 'semibold'
-			);
-			margin: 0;
-		}
+	.o-cookie-message__link--external,
+	.o-cookie-message__link {
+		@include oTypographySans($scale: 0);
+		@include oTypographyLink($theme: $link-theme);
+		white-space: nowrap;
+	}
 
-		.o-cookie-message__heading {
-			padding-right: $_o-cookie-message-spacing;
-
-			&:after {
-				content: '';
-				display: block;
-				width: 60px;
-				margin-top: oSpacingByName('s2');
-				margin-bottom: oSpacingByName('s3');
-				border-bottom: oSpacingByIncrement(1) solid;
-				border-color: oColorsByName('teal');
-			}
-		}
-
-		.o-cookie-message__action--secondary {
-			@include oGridRespondTo($until: M) {
-				margin-top: $_o-cookie-message-spacing / 4;
-			}
-		}
-
-		.o-cookie-message__link {
-			$link-theme: (
-				'base': 'teal',
-				'hover': 'teal',
-				'context': 'white'
-			);
-			@include oTypographyLink($theme: $link-theme);
-			@include oTypographySans($scale: 0);
-			white-space: nowrap;
-		}
-
-		.o-cookie-message__link--external {
-			@include oTypographyLink($external: true, $include-base-styles: false);
-		}
-
-		.o-cookie-message__link--external,
-		.o-cookie-message__link {
-			@include oTypographyLink($theme: (
-				'base': 'teal',
-				'hover': 'teal',
-				'context': 'white'
-			));
-		}
+	.o-cookie-message__link--external {
+		@include oTypographyLink(
+			$external: true,
+			$theme: $link-theme,
+			$include-base-styles: false
+		);
 	}
 }
-
 
 // Alternative cookie message styles (for whitelabel/specialist titles)
 @mixin _oCookieMessageAlternative() {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,4 +1,6 @@
 $o-cookie-message-is-silent: true !default;
 
 $_o-cookie-message-spacing: oSpacingByIncrement(10);
+// @deprecated "standard" is no longer a theme, it is the default, output with
+// base styles. Remove in the next breaking release.
 $_o-cookie-message-themes: ('standard', 'alternative');


### PR DESCRIPTION
The following Sass from the README did not work:
```scss
@include oCookieMessage($opts: (
	'themes': ('alternative')
));
```

Note for example the action link font size and the missing external link icon from "cookies":
![Screenshot 2020-11-25 at 12 50 47](https://user-images.githubusercontent.com/10405691/100229939-e3100600-2f1c-11eb-8d4c-8c9adb7e3621.png)


That's because the `alternative` theme builds on the `standard`
theme, with no modifier class `o-message--standard` the `standard`
theme effects all themes.

This commit removes `standard` as a theme and moves its styles
within the `_oCookieMessageBase` mixin, to be output by default
for other themes to build from.