### PR TITLE
Use the dialoge role.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,19 @@ Optionally add a theme attribute to change the colours of the cookie message `da
 
 ### Custom Cookie Message
 
-To display custom cookie message content with default buttons, add child HTML:
+To display custom cookie message content with default buttons, add child HTML along with associated `aria-labelledby` and `aria-describedby` attributes:
 ```html
-<div data-o-component="o-cookie-message" class="o-cookie-message">
+<div
+	role="dialog"
+	aria-labelledby="demo-label-element-id"
+	aria-describedby="demo-description-element-id"
+	data-o-component="o-cookie-message"
+	class="o-cookie-message">
 	<!-- custom cookie message copy / html here -->
+	<!-- include ids for the aria labelledby and describedby attributes -->
+	<!-- e.g. -->
+	<h2 id="demo-label-element-id">Custom Cookie Message</h2>
+	<p id="demo-description-element-id">We use cookies because...</p>
 </div>
 ```
 
@@ -39,14 +48,19 @@ To display custom cookie message content with default buttons, add child HTML:
 To support a core experience without JavaScript, add the full `o-cookie-message` markup as below. Update the anchors `redirect` query param with your sites URL, preferably the current page the cookie message is displayed on. This is used to send users back after setting cookie preferences in a core experience (where JavaScript is unavailable).
 
 ```html
-<div data-o-component="o-cookie-message" class="o-cookie-message">
+<div
+	role="dialog"
+	aria-labelledby="o-cookie-message-label"
+	aria-describedby="o-cookie-message-description"
+	data-o-component="o-cookie-message"
+	class="o-cookie-message">
 	<div class="o-cookie-message__outer">
 		<div class="o-cookie-message__inner">
 			<div class="o-cookie-message__content">
 				<div class="o-cookie-message__heading">
-					<h2>Cookies on the FT</h2>
+					<h2 id="o-cookie-message-label">Cookies on the FT</h2>
 				</div>
-				<p>
+				<p id="o-cookie-message-description">
 					We use
 					<a href="http://help.ft.com/help/legal-privacy/cookies/"
 						class="o-cookie-message__link o-cookie-message__link--external"

--- a/demos/src/custom-html-full.mustache
+++ b/demos/src/custom-html-full.mustache
@@ -1,4 +1,4 @@
-<div data-o-component="o-cookie-message" class="o-cookie-message">
+<div role="dialog" data-o-component="o-cookie-message" class="o-cookie-message">
 	<div class="o-cookie-message__outer">
 		<div class="o-cookie-message__inner">
 			<div class="o-cookie-message__content">

--- a/demos/src/custom-html.mustache
+++ b/demos/src/custom-html.mustache
@@ -1,3 +1,12 @@
-<div data-o-component="o-cookie-message" class="o-cookie-message">
-	[CUSTOM HTML IN HERE]
+<div
+	role="dialog"
+	aria-labelledby="demo-label-element-id"
+	aria-describedby="demo-description-element-id"
+	data-o-component="o-cookie-message"
+	class="o-cookie-message">
+	<!-- custom cookie message copy / html here -->
+	<!-- include ids for the aria labelledby and describedby attributes -->
+	<!-- e.g. -->
+	<h2 id="demo-label-element-id">Custom Cookie Message</h2>
+	<p id="demo-description-element-id">We use cookies because...</p>
 </div>

--- a/src/js/cookie-message.js
+++ b/src/js/cookie-message.js
@@ -86,11 +86,13 @@ class CookieMessage {
 	</div>
 </div>`;
 
+		const labelId = 'o-cookie-message-label';
+		const descriptionId = 'o-cookie-message-description';
 		const defaultContent = `
 <div class="o-cookie-message__heading">
-	<h2>Cookies on the FT</h2>
+	<h2 id="${labelId}">Cookies on the FT</h2>
 </div>
-<p>
+<p id="${descriptionId}">
 	We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a> for a number of reasons, such as keeping FT Sites reliable and secure, personalising content and ads, providing social media features and to analyse how our Sites are used.
 </p>`;
 
@@ -101,6 +103,10 @@ class CookieMessage {
 		} else if (html.trim() === "") {
 			// empty, provide default content
 			this.cookieMessageElement.innerHTML = wrapContent(defaultContent);
+			// with default content ids we can setup a labeled dialog role
+			this.cookieMessageElement.setAttribute('role', 'dialog');
+			this.cookieMessageElement.setAttribute('aria-labelledby', labelId);
+			this.cookieMessageElement.setAttribute('aria-describedby', descriptionId);
 		} else {
 			// some custom html, wrap it up
 			this.cookieMessageElement.innerHTML = wrapContent(html);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -22,9 +22,9 @@ function insert(html) {
 export function generateHTML(type) { insert(html[type]); }
 
 export const html = {
-	standard: `<div data-o-component="o-cookie-message" class='o-cookie-message'></div>`,
-	domAttributes: `<div data-o-component="o-cookie-message" data-o-cookie-message-accept-url="example.com" class='o-cookie-message'></div>`,
-	customCookieMessage: `<div data-o-component="o-cookie-message" data-o-cookie-message-use-custom-html="true" class='o-cookie-message'>
+	standard: `<div role="dialog" data-o-component="o-cookie-message" class='o-cookie-message'></div>`,
+	domAttributes: `<div role="dialog" data-o-component="o-cookie-message" data-o-cookie-message-accept-url="example.com" class='o-cookie-message'></div>`,
+	customCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" data-o-cookie-message-use-custom-html="true" class='o-cookie-message'>
 		Custom cookie message!
 		<div class="o-cookie-message__close-btn-container">
 			<button class="o-cookie-message__close-btn" data-o-component="o-cookie-message-close">
@@ -32,16 +32,16 @@ export const html = {
 			</button>
 		</div>
 	</div>`,
-	imperativeCookieMessage: `<div data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active">
+	imperativeCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active" aria-labelledby="o-cookie-message-label" aria-describedby="o-cookie-message-description">
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
-				<h2>Cookies on the FT</h2>
+				<h2 id="o-cookie-message-label">Cookies on the FT</h2>
 			</div>
-			<p>
+			<p id="o-cookie-message-description">
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
 				content and ads, providing social media features and to analyse how our Sites are used.
@@ -62,16 +62,16 @@ export const html = {
 			</div>
 		</div>
 	</div>`,
-	imperativeAltCookieMessage: `<div data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active o-cookie-message--alternative">
+	imperativeAltCookieMessage: `<div role="dialog" data-o-component="o-cookie-message" class="o-cookie-message o-cookie-message--active o-cookie-message--alternative" aria-labelledby="o-cookie-message-label" aria-describedby="o-cookie-message-description">
 		<div class="o-cookie-message__outer">
 			<div class="o-cookie-message__inner">
 
 			<div class="o-cookie-message__content">
 
 			<div class="o-cookie-message__heading">
-				<h2>Cookies on the FT</h2>
+				<h2 id="o-cookie-message-label">Cookies on the FT</h2>
 			</div>
-			<p>
+			<p id="o-cookie-message-description">
 				We use <a href="http://help.ft.com/help/legal-privacy/cookies/" class="o-cookie-message__link o-cookie-message__link--external" target="_blank" rel="noopener">cookies</a>
 				for a number of reasons, such as keeping FT Sites reliable and secure, personalising
 				content and ads, providing social media features and to analyse how our Sites are used.


### PR DESCRIPTION
>The dialog role is used to mark up an HTML based application dialog or window
>that separates content or UI from the rest of the web application or page.
>Dialogs are generally placed on top of the rest of the page content using an
>overlay. Dialogs can be either non-modal (it's still possible to interact with
>content outside of the dialog) or modal (only the content in the dialog can be
>interacted with).
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role

In the future we can use the `dialog` element:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog

Users who have implemented custom html or the core experience
will need to update their markup. Customer Products were
already using the dialog role and will do with the move to
o-cookie-message:
https://github.com/Financial-Times/n-messaging-client/pull/329