### PR TITLE
Update the manage cookies demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To support a core experience without JavaScript, add the full `o-cookie-message`
 				</div>
 
 				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://cookies.ft.com/preferences/manage-cookies?redirect=#" class="o-cookie-message__link">Manage cookies</a>
+					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#" class="o-cookie-message__link">Manage cookies</a>
 				</div>
 			</div>
 		</div>

--- a/demos/src/custom-html-full.mustache
+++ b/demos/src/custom-html-full.mustache
@@ -27,7 +27,7 @@
 
 				<!-- note: update action redirect, see README for more details -->
 				<div class="o-cookie-message__action o-cookie-message__action--secondary">
-					<a href="https://cookies.ft.com/preferences/manage-cookies?redirect=#"
+					<a href="https://www.ft.com/preferences/manage-cookies?redirect=#"
 						class="o-cookie-message__link">Manage cookies</a>
 				</div>
 			</div>


### PR DESCRIPTION
ft.com are moving from `cookies.ft.com` to `www.ft.com` for the manage
cookies page and are going to use relative links. To ensure no
future copy/paste error update the examples in `o-cookie-message`